### PR TITLE
REALMC-12720: Handle "items" array inputs gracefully

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -459,7 +459,11 @@ func (d *Schema) parseSchema(documentNode interface{}, currentSchema *subSchema)
 	// items
 	if existsMapKey(m, KEY_ITEMS) {
 		if isKind(m[KEY_ITEMS], reflect.Slice) {
-			for _, itemElement := range m[KEY_ITEMS].([]interface{}) {
+			itemElements, ok := m[KEY_ITEMS].([]interface{})
+			if !ok {
+				return errors.New("items value is not an []interface{}")
+			}
+			for _, itemElement := range itemElements {
 				if isKind(itemElement, reflect.Map, reflect.Bool) {
 					newSchema := NewSubSchema(KEY_ITEMS, currentSchema)
 					currentSchema.AddItemsChild(newSchema)


### PR DESCRIPTION
## Description

This PR makes passing in non `[]interface{}` values as the array argument of "items" not panic

ie:

Before this PR,

passing in:

```go
bson.D{
  {"type", "array"},
  {"items", []bson.D{ {"type", "string"} }
}
```

to `gojsonschema.NewSchema()` and `schema.Validate` would panic